### PR TITLE
 fixed import detection, added more patterns for url detection, bumped intl version

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ dart pub run string_extractor_intl:extract_strings
 **Extract and replace in files:**
 
 ```bash
-dart pub run string_extractor_intl:extract_strings --replace
+dart run string_extractor_intl:extract_strings --replace
 ```
 
 **Custom configuration:**
 
 ```bash
-dart pub run string_extractor_intl:extract_strings \
+dart run string_extractor_intl:extract_strings \
   --input lib/presentation \
   --output assets/l10n \
   --template-arb strings_en.arb \
@@ -78,7 +78,7 @@ dart pub run string_extractor_intl:extract_strings \
 **Show help:**
 
 ```bash
-dart pub run string_extractor_intl:extract_strings --help
+dart run string_extractor_intl:extract_strings --help
 ```
 
 ### Command Line Options

--- a/lib/string_extractor_intl.dart
+++ b/lib/string_extractor_intl.dart
@@ -301,7 +301,7 @@ class LocalizationStringExtractor {
 
   bool _isImportExportStatement(String content, int position) {
     int lineStart = content.lastIndexOf('\n', position - 1) + 1;
-    String linePrefix = content.substring(lineStart, position).trim();
+    String linePrefix = content.substring(lineStart, position);
 
     return linePrefix.startsWith('import ') ||
         linePrefix.startsWith('export ') ||
@@ -317,15 +317,16 @@ class LocalizationStringExtractor {
 
     final ignoredPatterns = [
       'assets/', 'fonts/', 'images/', '.png', '.jpg', '.jpeg', '.svg', '.json', '.dart',
-      'MaterialApp', 'StatelessWidget', 'StatefulWidget', 'key:', 'const ', 'super.key',
-      'DateTime.now()', 'Colors.', 'EdgeInsets.', 'BorderRadius.', 'BoxShadow(', 'FontWeight.',
-      'TextStyle(', 'IconData(', 'Alignment.', 'MainAxisAlignment.', 'CrossAxisAlignment.',
-      'TextDirection.', 'FlexFit.', 'Clip.', 'BlendMode.', 'BoxFit.', 'FilterQuality.',
-      'ImageRepeat.', 'Locale(', 'TargetPlatform.', 'Brightness.', 'ThemeMode.', 'FloatingActionButtonLocation.',
-      'TextCapitalization.', 'TextInputAction.', 'TextInputType.', 'Overflow.', 'StackFit.',
-      'WrapAlignment.', 'WrapCrossAlignment.', 'VerticalDirection.', 'Axis.', 'BoxShape.',
-      'BoxBorder.', 'BorderStyle.', 'TableBorder.', 'TableCellVerticalAlignment.', 'TableRowInkDecoration.',
-      'HitTestBehavior.', 'MaterialType.', 'MaterialTapTargetSize.', 'SnackBarBehavior.', 'SnackBarClosedReason.',
+      '.com', '.org', '.net', '.io', '.app', 'www.', 'Key(', 'MaterialApp', 'StatelessWidget',
+      'StatefulWidget', 'key:', 'const ', 'super.key', 'DateTime.now()', 'Colors.', 'EdgeInsets.',
+      'BorderRadius.', 'BoxShadow(', 'FontWeight.', 'TextStyle(', 'IconData(', 'Alignment.',
+      'MainAxisAlignment.', 'CrossAxisAlignment.', 'TextDirection.', 'FlexFit.', 'Clip.', 'BlendMode.',
+      'BoxFit.', 'FilterQuality.', 'ImageRepeat.', 'Locale(', 'TargetPlatform.', 'Brightness.',
+      'ThemeMode.', 'FloatingActionButtonLocation.', 'TextCapitalization.', 'TextInputAction.',
+      'TextInputType.', 'Overflow.', 'StackFit.', 'WrapAlignment.', 'WrapCrossAlignment.',
+      'VerticalDirection.', 'Axis.', 'BoxShape.', 'BoxBorder.', 'BorderStyle.', 'TableBorder.',
+      'TableCellVerticalAlignment.', 'TableRowInkDecoration.', 'HitTestBehavior.', 'MaterialType.',
+      'MaterialTapTargetSize.', 'SnackBarBehavior.', 'SnackBarClosedReason.',
       'TooltipTriggerMode.', 'AdaptiveTextSelectionToolbar.buttonItems','print('
     ];
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -109,10 +109,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   file:
     dependency: transitive
     description:
@@ -175,10 +175,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.0"
+    version: "0.20.2"
   io:
     dependency: transitive
     description:
@@ -207,26 +207,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -420,26 +420,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "301b213cd241ca982e9ba50266bd3f5bd1ea33f1455554c5abb85d1be0e2d87e"
+      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
       url: "https://pub.dev"
     source: hosted
-    version: "1.25.15"
+    version: "1.26.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.6"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "84d17c3486c8dfdbe5e12a50c8ae176d15e2a771b96909a9442b40173649ccaa"
+      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.8"
+    version: "0.6.11"
   typed_data:
     dependency: transitive
     description:
@@ -452,10 +452,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -513,5 +513,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.7.2 <4.0.0"
+  dart: ">=3.8.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   args: ^2.4.2
   path: ^1.8.3
   yaml: ^3.1.2
-  intl: ^0.19.0
+  intl: ^0.20.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
With the import detection, it turns out the `.trim()` was clipping the trailing space so the `linePrefix.startsWith('import ')` wasn't actually catching anything and instead all the imports were getting caught by the `_shouldIgnoreString` function.
I noticed this because it wasn't catching `import 'dart:async';` which I use a lot.

Also, I have added some common TLDs and stuff to the `_shouldIgnoreString` list because it wasn't catching some website links and things that I had in my project.
Sidenote: I think I may add a 'strict mode' or something in the future that adds a lot more restrictions because it seems to be trying to translate some of my hardcoded maps and stuff too.

I've also removed the 'pub' from the README because it is deprecated.

Oh, and I bumped the intl version.

If there is anything I need to do / haven't done right, please give me a yell.